### PR TITLE
refactor: migrate from Google Calendar to Google Tasks API

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -115,6 +115,12 @@
             <artifactId>google-api-services-calendar</artifactId>
             <version>v3-rev411-1.25.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.apis</groupId>
+            <artifactId>google-api-services-tasks</artifactId>
+            <version>v1-rev20210709-1.32.1</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/backend/src/main/java/com/taskvantage/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/taskvantage/backend/config/SecurityConfig.java
@@ -180,10 +180,12 @@ public class SecurityConfig {
                 .getBuilder("google")
                 .clientId("872741914932-asspmr6jois4ovvr3bvjm4p44csq9qjs.apps.googleusercontent.com")
                 .clientSecret(googleClientSecret)
-                .scope("openid", "profile", "email", "https://www.googleapis.com/auth/calendar")
+                .scope("openid",
+                        "profile",
+                        "email",
+                        "https://www.googleapis.com/auth/calendar",
+                        "https://www.googleapis.com/auth/tasks")
                 .redirectUri(backendUrl + "/login/oauth2/code/google")
-                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-                .tokenUri("https://oauth2.googleapis.com/token")
                 .build();
     }
 

--- a/backend/src/main/java/com/taskvantage/backend/service/TaskServiceImpl.java
+++ b/backend/src/main/java/com/taskvantage/backend/service/TaskServiceImpl.java
@@ -44,16 +44,18 @@ public class TaskServiceImpl implements TaskService {
                 user.isTaskSyncEnabled()) {
             try {
                 if (task.getScheduledStart() != null && task.getDueDate() != null) {
-                    googleCalendarService.createCalendarEvent(
+                    // Using Google Tasks API instead of Calendar Events
+                    googleCalendarService.createGoogleTask(
                             user,
                             task.getTitle(),
                             task.getScheduledStart(),
-                            task.getDueDate()
+                            task.getDueDate(),
+                            task.getDescription() // Optionally include description if available
                     );
                 }
             } catch (GeneralSecurityException | IOException e) {
                 // Log the error but don't fail the task operation
-                logger.error("Failed to sync task with Google Calendar", e);
+                logger.error("Failed to sync task with Google Tasks", e);
             }
         }
     }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -48,7 +48,7 @@ spring.security.oauth2.client.registration.google.provider=google
 spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CAL_ID}
 spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CAL_SECRET}
 spring.security.oauth2.client.registration.google.authorization-grant-type=authorization_code
-spring.security.oauth2.client.registration.google.scope=openid,profile,email,https://www.googleapis.com/auth/calendar
+spring.security.oauth2.client.registration.google.scope=openid,profile,email,https://www.googleapis.com/auth/tasks
 spring.security.oauth2.client.registration.google.client-authentication-method=client_secret_basic
 
 # Provider Configuration

--- a/frontend/task-manager/src/app/services/user.service.ts
+++ b/frontend/task-manager/src/app/services/user.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { catchError, Observable, tap } from 'rxjs';
 import { environment } from '../../environments/environment';
 
 @Injectable({
@@ -29,10 +29,17 @@ export class UserService {
 
   // Update task sync preference
   updateTaskSync(enabled: boolean): Observable<any> {
+    console.log('UserService: Sending task sync update request:', enabled);
     return this.http.post(
       `${this.apiUrl}/api/oauth2/google/sync-settings`,
       { enabled },
       { headers: this.getHeaders() }
+    ).pipe(
+      tap(response => console.log('UserService: Received response:', response)),
+      catchError(error => {
+        console.error('UserService: Error updating task sync:', error);
+        throw error;
+      })
     );
-  }
+}
 }

--- a/frontend/task-manager/src/app/settings/settings.component.ts
+++ b/frontend/task-manager/src/app/settings/settings.component.ts
@@ -81,18 +81,20 @@ export class SettingsComponent implements OnInit {
   }
 
   private loadUserSettings(): void {
+    console.log('SettingsComponent: Loading user settings');
     this.userService.getUserSettings().subscribe({
       next: (settings) => {
-        this.isTaskSyncEnabled = settings.taskSyncEnabled;
+        console.log('SettingsComponent: Received settings:', settings);
+        this.isTaskSyncEnabled = settings.taskSyncEnabled || settings.enabled; // Check both properties
       },
       error: (error) => {
-        console.error('Error loading user settings:', error);
+        console.error('SettingsComponent: Error loading user settings:', error);
         this.snackBar.open('Failed to load settings', 'Close', {
           duration: 3000
         });
       }
     });
-  }
+}
 
   connectGoogleCalendar(): void {
     // Attempt to retrieve userId from route parameters
@@ -116,9 +118,15 @@ export class SettingsComponent implements OnInit {
   }
 
   toggleTaskSync(enabled: boolean): void {
+    console.log('SettingsComponent: Toggling task sync to:', enabled);
     this.userService.updateTaskSync(enabled).subscribe({
       next: (response) => {
+        console.log('SettingsComponent: Update response:', response);
         this.isTaskSyncEnabled = enabled;
+        
+        // Verify the setting was saved by fetching current state
+        this.loadUserSettings();
+        
         this.snackBar.open(
           `Task sync ${enabled ? 'enabled' : 'disabled'}`,
           'Close',
@@ -126,15 +134,14 @@ export class SettingsComponent implements OnInit {
         );
       },
       error: (error) => {
-        console.error('Error updating task sync:', error);
+        console.error('SettingsComponent: Error updating task sync:', error);
         this.snackBar.open('Failed to update task sync settings', 'Close', {
-          duration: 3000
-        });
+          duration: 3000 });
         // Revert the toggle if the update failed
         this.isTaskSyncEnabled = !enabled;
       }
     });
-  }
+}
 
   disconnectGoogleCalendar(): void {
     // Open the loading dialog


### PR DESCRIPTION
- Replace Google Calendar event creation with Google Tasks integration
- Fix OAuth2 scope issues for Google Tasks API access
- Add proper error handling for Tasks API operations
- Update security config to include Tasks API permissions
- Add fallback for creating default task list if none exists

Breaking change: Users will need to re-authorize Google account access